### PR TITLE
add "actions" for migration paths

### DIFF
--- a/src/Console/Migrate.php
+++ b/src/Console/Migrate.php
@@ -74,8 +74,8 @@ class Migrate extends BaseCommand
             return $paths;
         }
 
-        return array_merge(
-            $this->migrator->paths(), [$this->getMigrationPath()]
-        );
+        return array_merge(array_map(static function($path) {
+            return $path . DIRECTORY_SEPARATOR . 'actions';
+        }, $this->migrator->paths()), [$this->getMigrationPath()]);
     }
 }

--- a/src/Console/Migrate.php
+++ b/src/Console/Migrate.php
@@ -75,7 +75,7 @@ class Migrate extends BaseCommand
         }
 
         return array_merge(array_map(static function($path) {
-            return $path . DIRECTORY_SEPARATOR . 'actions';
+            return $path.DIRECTORY_SEPARATOR.'actions';
         }, $this->migrator->paths()), [$this->getMigrationPath()]);
     }
 }

--- a/src/Console/Rollback.php
+++ b/src/Console/Rollback.php
@@ -40,6 +40,7 @@ class Rollback extends RollbackCommand
             return 1;
         }
 
+
         $this->migrator->usingConnection($this->optionDatabase(), function () {
             $this->migrator->setOutput($this->output)->rollback(
                 $this->getMigrationPaths(),
@@ -64,5 +65,16 @@ class Rollback extends RollbackCommand
 
             ['step', null, InputOption::VALUE_OPTIONAL, 'The number of actions to be reverted'],
         ];
+    }
+
+    protected function getMigrationPaths(): array
+    {
+        if ($this->input->hasOption('path') && $this->option('path')) {
+            return parent::getMigrationPaths();
+        }
+
+        return array_merge(array_map(static function($path) {
+            return $path.DIRECTORY_SEPARATOR.'actions';
+        }, $this->migrator->paths()), [$this->getMigrationPath()]);
     }
 }


### PR DESCRIPTION
прошу рассмотреть добавление actions к путям, которые зарегистрированы сторонними пакетами
в моем случае migration-actions без добавление actions к путям, пытается выполнить миграцию из папки для миграций базы данных.

Спасибо.
