### PR TITLE
Cannot assign string to property `Values\Options::$step` of type `?int`

### DIFF
--- a/src/Values/Options.php
+++ b/src/Values/Options.php
@@ -6,6 +6,7 @@ namespace DragonCode\LaravelActions\Values;
 
 use DragonCode\LaravelActions\Helpers\Config;
 use DragonCode\SimpleDataTransferObject\DataTransferObject;
+use DragonCode\Support\Facades\Helpers\Boolean;
 use DragonCode\Support\Facades\Helpers\Str;
 use Illuminate\Container\Container;
 
@@ -47,6 +48,26 @@ class Options extends DataTransferObject
             ->map(fn (string $path) => Str::snake($path))
             ->implode(DIRECTORY_SEPARATOR)
             ->toString();
+    }
+
+    protected function castBefore(mixed $value): bool
+    {
+        return Boolean::parse($value);
+    }
+
+    protected function castForce(mixed $value): bool
+    {
+        return Boolean::parse($value);
+    }
+
+    protected function castRealpath(mixed $value): bool
+    {
+        return Boolean::parse($value);
+    }
+
+    protected function castStep(string|int|null $value): ?int
+    {
+        return is_numeric($value) ? (int) $value : null;
     }
 
     protected function config(): Config


### PR DESCRIPTION
…ions::$step of type ?int

<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
