### PR TITLE
[3.x] Isolating Action Execution

### DIFF
--- a/config/actions.php
+++ b/config/actions.php
@@ -24,7 +24,7 @@ return [
     |
     */
 
-    'table' => 'migration_actions',
+    'table'      => 'migration_actions',
 
     /*
     |--------------------------------------------------------------------------
@@ -35,7 +35,7 @@ return [
     |
     */
 
-    'path' => base_path('actions'),
+    'path'       => base_path('actions'),
 
     /*
     |--------------------------------------------------------------------------
@@ -56,5 +56,5 @@ return [
     |
     */
 
-    'exclude' => null,
+    'exclude'    => null,
 ];

--- a/docs/how-to-use/running.md
+++ b/docs/how-to-use/running.md
@@ -22,6 +22,18 @@ bar/2022_10_14_000003_test3  # 3
 2022_10_14_000004_test4      # 4
 ```
 
+## Isolating Action Execution
+
+If you are deploying your application across multiple servers and running migrations as part of your deployment process, you likely do not want two servers attempting to migrate
+the database at the same time. To avoid this, you may use the `isolated` option when invoking the `migrate:actions` command.
+
+When the `isolated` option is provided, Laravel will acquire an atomic lock using your application's cache driver before attempting to run your migrations. All other attempts to
+run the `migrate:actions` command while that lock is held will not execute; however, the command will still exit with a successful exit status code:
+
+```bash
+php artisan migrate:actions --isolated
+```
+
 ## Split Launch Option
 
 Sometimes it becomes necessary to launch actions separately, for example, to notify about the successful deployment of a project.
@@ -39,7 +51,7 @@ For backwards compatibility, the `before` parameter is set to `true` by default,
 ```php
 use DragonCode\LaravelActions\Action;
 
-return new class () extends Action
+return new class extends Action
 {
     protected $before = false;
 
@@ -95,7 +107,7 @@ To do this, override the `$once` variable in the action file:
 ```php
 use DragonCode\LaravelActions\Action;
 
-return new class () extends Action
+return new class extends Action
 {
     protected $once = false;
 
@@ -123,7 +135,7 @@ For this you can use the `$environment` parameter:
 ```php
 use DragonCode\LaravelActions\Action;
 
-return new class () extends Action
+return new class extends Action
 {
     /** @var string|array|null */
     protected $environment = 'production';
@@ -140,7 +152,7 @@ You can also specify multiple environment names:
 ```php
 use DragonCode\LaravelActions\Action;
 
-return new class () extends Action
+return new class extends Action
 {
     /** @var string|array|null */
     protected $environment = ['testing', 'staging'];
@@ -163,7 +175,7 @@ For this you can use the `$except_environment` parameter:
 ```php
 use DragonCode\LaravelActions\Action;
 
-return new class () extends Action
+return new class extends Action
 {
     /** @var string|array|null */
     protected $exceptEnvironment = 'production';
@@ -180,7 +192,7 @@ You can also specify multiple environment names:
 ```php
 use DragonCode\LaravelActions\Action;
 
-return new class () extends Action
+return new class extends Action
 {
     /** @var string|array|null */
     protected $exceptEnvironment = ['testing', 'staging'];
@@ -205,7 +217,7 @@ will reduce the time it takes to create the action.
 ```php
 use DragonCode\LaravelActions\Action;
 
-return new class () extends Action
+return new class extends Action
 {
     protected $transactions = true;
 

--- a/src/Concerns/Isolatable.php
+++ b/src/Concerns/Isolatable.php
@@ -26,7 +26,11 @@ trait Isolatable
 
     protected function isolatedStatusCode(): int
     {
-        return (int) (is_numeric($this->getIsolateOption()) ? $this->getIsolateOption() : self::SUCCESS);
+        if ($isolate = $this->getIsolateOption()) {
+            return is_numeric($isolate) ? $isolate : self::SUCCESS;
+        }
+
+        return self::SUCCESS;
     }
 
     protected function getIsolateOption(): int|bool

--- a/src/Concerns/Isolatable.php
+++ b/src/Concerns/Isolatable.php
@@ -9,16 +9,6 @@ use DragonCode\LaravelActions\Services\Mutex;
 
 trait Isolatable
 {
-    protected function isolationCreate(): bool
-    {
-        return $this->isolationMutex()->create($this);
-    }
-
-    protected function isolationForget(): void
-    {
-        $this->isolationMutex()->forget($this);
-    }
-
     protected function isolationMutex(): Mutex
     {
         return $this->getLaravel()->make(Mutex::class);

--- a/src/Concerns/Isolatable.php
+++ b/src/Concerns/Isolatable.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DragonCode\LaravelActions\Concerns;
+
+use DragonCode\LaravelActions\Constants\Options;
+use DragonCode\LaravelActions\Services\Mutex;
+
+trait Isolatable
+{
+    protected function isolationCreate(): bool
+    {
+        return $this->isolationMutex()->create($this);
+    }
+
+    protected function isolationForget(): void
+    {
+        $this->isolationMutex()->forget($this);
+    }
+
+    protected function isolationMutex(): Mutex
+    {
+        return $this->getLaravel()->make(Mutex::class);
+    }
+
+    protected function isolatedStatusCode(): int
+    {
+        return (int) (is_numeric($this->option(Options::ISOLATED)) ? $this->option(Options::ISOLATED) : self::SUCCESS);
+    }
+}

--- a/src/Concerns/Isolatable.php
+++ b/src/Concerns/Isolatable.php
@@ -26,6 +26,16 @@ trait Isolatable
 
     protected function isolatedStatusCode(): int
     {
-        return (int) (is_numeric($this->option(Options::ISOLATED)) ? $this->option(Options::ISOLATED) : self::SUCCESS);
+        return (int) (is_numeric($this->getIsolateOption()) ? $this->getIsolateOption() : self::SUCCESS);
+    }
+
+    protected function getIsolateOption(): int|bool
+    {
+        return $this->hasIsolateOption() ? $this->option(Options::ISOLATED) : false;
+    }
+
+    protected function hasIsolateOption(): bool
+    {
+        return $this->hasOption(Options::ISOLATED) && $this->option(Options::ISOLATED);
     }
 }

--- a/src/Concerns/Optionable.php
+++ b/src/Concerns/Optionable.php
@@ -18,6 +18,7 @@ trait Optionable
         Options::CONNECTION,
         Options::FORCE,
         Options::MUTE,
+        Options::ISOLATED,
     ];
 
     protected function configure(): void
@@ -49,6 +50,7 @@ trait Optionable
             [Options::REALPATH, null, InputOption::VALUE_NONE, 'Indicate any provided action file paths are pre-resolved absolute path'],
             [Options::STEP, null, InputOption::VALUE_OPTIONAL, 'Force the actions to be run so they can be rolled back individually'],
             [Options::MUTE, null, InputOption::VALUE_NONE, 'Turns off the output of informational messages'],
+            [Options::ISOLATED, null, InputOption::VALUE_OPTIONAL, 'Do not run the actions command if another instance of the actions command is already running'],
         ];
     }
 

--- a/src/Concerns/Optionable.php
+++ b/src/Concerns/Optionable.php
@@ -50,7 +50,7 @@ trait Optionable
             [Options::REALPATH, null, InputOption::VALUE_NONE, 'Indicate any provided action file paths are pre-resolved absolute path'],
             [Options::STEP, null, InputOption::VALUE_OPTIONAL, 'Force the actions to be run so they can be rolled back individually'],
             [Options::MUTE, null, InputOption::VALUE_NONE, 'Turns off the output of informational messages'],
-            [Options::ISOLATED, null, InputOption::VALUE_OPTIONAL, 'Do not run the actions command if another instance of the actions command is already running'],
+            [Options::ISOLATED, null, InputOption::VALUE_OPTIONAL, 'Do not run the actions command if another instance of the actions command is already running', false],
         ];
     }
 

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -7,7 +7,6 @@ namespace DragonCode\LaravelActions\Console;
 use DragonCode\LaravelActions\Concerns\ConfirmableTrait;
 use DragonCode\LaravelActions\Concerns\Isolatable;
 use DragonCode\LaravelActions\Concerns\Optionable;
-use DragonCode\LaravelActions\Constants\Options;
 use DragonCode\LaravelActions\Processors\Processor;
 use DragonCode\LaravelActions\Values\Options as OptionsDto;
 use Illuminate\Console\Command as BaseCommand;
@@ -37,17 +36,17 @@ abstract class Command extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
-        if ($this->option(Options::ISOLATED) !== false && ! $this->isolationCreate()) {
-            $this->comment(sprintf('The [%s] command is already running.', $this->getName()));
-
-            return $this->isolatedStatusCode();
-        }
-
         try {
+            if ($this->getIsolateOption() !== false && ! $this->isolationCreate()) {
+                $this->comment(sprintf('The [%s] command is already running.', $this->getName()));
+
+                return $this->isolatedStatusCode();
+            }
+
             return parent::execute($input, $output);
         }
         finally {
-            if ($this->option(Options::ISOLATED) !== false) {
+            if ($this->getIsolateOption() !== false) {
                 $this->isolationForget();
             }
         }

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -37,7 +37,7 @@ abstract class Command extends BaseCommand
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         try {
-            if ($this->getIsolateOption() !== false && ! $this->isolationCreate()) {
+            if ($this->getIsolateOption() !== false && ! $this->isolationMutex()->create($this)) {
                 $this->comment(sprintf('The [%s] command is already running.', $this->getName()));
 
                 return $this->isolatedStatusCode();
@@ -47,7 +47,7 @@ abstract class Command extends BaseCommand
         }
         finally {
             if ($this->getIsolateOption() !== false) {
-                $this->isolationForget();
+                $this->isolationMutex()->forget($this);
             }
         }
     }

--- a/src/Console/Command.php
+++ b/src/Console/Command.php
@@ -36,13 +36,13 @@ abstract class Command extends BaseCommand
 
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
+        if ($this->getIsolateOption() !== false && ! $this->isolationMutex()->create($this)) {
+            $this->comment(sprintf('The [%s] command is already running.', $this->getName()));
+
+            return $this->isolatedStatusCode();
+        }
+
         try {
-            if ($this->getIsolateOption() !== false && ! $this->isolationMutex()->create($this)) {
-                $this->comment(sprintf('The [%s] command is already running.', $this->getName()));
-
-                return $this->isolatedStatusCode();
-            }
-
             return parent::execute($input, $output);
         }
         finally {

--- a/src/Console/Fresh.php
+++ b/src/Console/Fresh.php
@@ -23,5 +23,6 @@ class Fresh extends Command
         Options::PATH,
         Options::REALPATH,
         Options::MUTE,
+        Options::ISOLATED,
     ];
 }

--- a/src/Console/Migrate.php
+++ b/src/Console/Migrate.php
@@ -23,5 +23,6 @@ class Migrate extends Command
         Options::PATH,
         Options::REALPATH,
         Options::MUTE,
+        Options::ISOLATED,
     ];
 }

--- a/src/Console/Refresh.php
+++ b/src/Console/Refresh.php
@@ -21,5 +21,6 @@ class Refresh extends Command
         Options::PATH,
         Options::REALPATH,
         Options::MUTE,
+        Options::ISOLATED,
     ];
 }

--- a/src/Console/Reset.php
+++ b/src/Console/Reset.php
@@ -21,5 +21,6 @@ class Reset extends Command
         Options::PATH,
         Options::REALPATH,
         Options::MUTE,
+        Options::ISOLATED,
     ];
 }

--- a/src/Console/Rollback.php
+++ b/src/Console/Rollback.php
@@ -22,5 +22,6 @@ class Rollback extends Command
         Options::REALPATH,
         Options::STEP,
         Options::MUTE,
+        Options::ISOLATED,
     ];
 }

--- a/src/Constants/Options.php
+++ b/src/Constants/Options.php
@@ -12,6 +12,8 @@ class Options
 
     public const FORCE = 'force';
 
+    public const ISOLATED = 'isolated';
+
     public const MUTE = 'mute';
 
     public const NAME = 'name';

--- a/src/Services/Mutex.php
+++ b/src/Services/Mutex.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DragonCode\LaravelActions\Services;
+
+use Carbon\CarbonInterval;
+use DragonCode\LaravelActions\Console\Command;
+use Illuminate\Contracts\Cache\Factory as Cache;
+use Illuminate\Contracts\Cache\Repository;
+
+class Mutex
+{
+    protected ?string $store = null;
+
+    public function __construct(
+        protected Cache $cache
+    ) {
+    }
+
+    public function create(Command $command): bool
+    {
+        return $this->store()->add($this->name($command), true, $this->ttl());
+    }
+
+    public function forget(Command $command): void
+    {
+        $this->store()->forget(
+            $this->name($command)
+        );
+    }
+
+    protected function store(): Repository
+    {
+        return $this->cache->store($this->store);
+    }
+
+    protected function ttl(): CarbonInterval
+    {
+        return CarbonInterval::hour();
+    }
+
+    protected function name(Command $command): string
+    {
+        return 'framework' . DIRECTORY_SEPARATOR . 'action-' . $command->getName();
+    }
+}

--- a/tests/Commands/MutexTest.php
+++ b/tests/Commands/MutexTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Commands;
+
+use DragonCode\LaravelActions\Constants\Names;
+use Tests\TestCase;
+
+class MutexTest extends TestCase
+{
+    public function testMigrationCommand()
+    {
+        $this->assertDatabaseDoesntTable($this->table);
+
+        $this->artisan(Names::INSTALL)->assertExitCode(0);
+
+        $this->assertDatabaseHasTable($this->table);
+        $this->assertDatabaseCount($this->table, 0);
+
+        $this->artisan(Names::MAKE, ['name' => 'TestMigration'])->assertExitCode(0);
+        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+
+        $this->assertDatabaseCount($this->table, 1);
+        $this->assertDatabaseMigrationHas($this->table, 'test_migration');
+    }
+}

--- a/tests/Commands/MutexTest.php
+++ b/tests/Commands/MutexTest.php
@@ -47,7 +47,6 @@ class MutexTest extends TestCase
             ->once();
 
         $this->mutex->shouldReceive('forget')
-            ->never()
             ->once();
 
         $this->runCommand();
@@ -62,8 +61,7 @@ class MutexTest extends TestCase
             ->once();
 
         $this->mutex->shouldReceive('forget')
-            ->never()
-            ->once();
+            ->never();
 
         $this->runCommand();
 
@@ -77,7 +75,6 @@ class MutexTest extends TestCase
             ->twice();
 
         $this->mutex->shouldReceive('forget')
-            ->never()
             ->twice();
 
         $this->runCommand();

--- a/tests/Commands/MutexTest.php
+++ b/tests/Commands/MutexTest.php
@@ -4,24 +4,102 @@ declare(strict_types=1);
 
 namespace Tests\Commands;
 
-use DragonCode\LaravelActions\Constants\Names;
+use DragonCode\LaravelActions\Console\Command;
+use DragonCode\LaravelActions\Constants\Options;
+use DragonCode\LaravelActions\Services\Mutex;
+use Illuminate\Container\Container;
+use Mockery as m;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
 use Tests\TestCase;
 
 class MutexTest extends TestCase
 {
-    public function testMigrationCommand()
+    protected Command $command;
+
+    protected Mutex $mutex;
+
+    public function testCanRunIsolatedCommandIfNotBlocked()
     {
-        $this->assertDatabaseDoesntTable($this->table);
+        $this->mutex->shouldReceive('create')
+            ->andReturn(true)
+            ->once();
 
-        $this->artisan(Names::INSTALL)->assertExitCode(0);
+        $this->mutex->shouldReceive('forget')
+            ->never()
+            ->once();
 
-        $this->assertDatabaseHasTable($this->table);
-        $this->assertDatabaseCount($this->table, 0);
+        $this->runCommand();
 
-        $this->artisan(Names::MAKE, ['name' => 'TestMigration'])->assertExitCode(0);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->assertSame(1, $this->command->ran);
+    }
 
-        $this->assertDatabaseCount($this->table, 1);
-        $this->assertDatabaseMigrationHas($this->table, 'test_migration');
+    public function testCannotRunIsolatedCommandIfBlocked()
+    {
+        $this->mutex->shouldReceive('create')
+            ->andReturn(false)
+            ->once();
+
+        $this->mutex->shouldReceive('forget')
+            ->never()
+            ->once();
+
+        $this->runCommand();
+
+        $this->assertSame(0, $this->command->ran);
+    }
+
+    public function testCanRunCommandAgainAfterOtherCommandFinished()
+    {
+        $this->mutex->shouldReceive('create')
+            ->andReturn(true)
+            ->twice();
+
+        $this->mutex->shouldReceive('forget')
+            ->never()
+            ->twice();
+
+        $this->runCommand();
+        $this->runCommand();
+
+        $this->assertEquals(2, $this->command->ran);
+    }
+
+    public function testCanRunCommandAgainNonAutomated()
+    {
+        $this->mutex->shouldNotHaveBeenCalled();
+
+        $this->runCommand(false);
+
+        $this->assertEquals(1, $this->command->ran);
+    }
+
+    protected function setUp(): void
+    {
+        $this->command = new class extends Command
+        {
+            public int $ran = 0;
+
+            public function handle(): int
+            {
+                $this->ran++;
+
+                return self::SUCCESS;
+            }
+        };
+
+        $this->mutex = m::mock(Mutex::class);
+
+        $container = Container::getInstance();
+        $container->instance(Mutex::class, $this->mutex);
+        $this->command->setLaravel($container);
+    }
+
+    protected function runCommand($withIsolated = true)
+    {
+        $input  = new ArrayInput(['--' . Options::ISOLATED => $withIsolated]);
+        $output = new NullOutput;
+
+        $this->command->run($input, $output);
     }
 }


### PR DESCRIPTION
If you are deploying your application across multiple servers and running migrations as part of your deployment process, you likely do not want two servers attempting to migrate
the database at the same time. To avoid this, you may use the `isolated` option when invoking the `migrate:actions` command.

When the `isolated` option is provided, Laravel will acquire an atomic lock using your application's cache driver before attempting to run your migrations. All other attempts to
run the `migrate:actions` command while that lock is held will not execute; however, the command will still exit with a successful exit status code:

```bash
php artisan migrate:actions --isolated
```