### PR TITLE
`Names::MIGRATE` constant have been renamed to `Names::ACTIONS`

### DIFF
--- a/src/Console/Migrate.php
+++ b/src/Console/Migrate.php
@@ -9,7 +9,7 @@ use DragonCode\LaravelActions\Processors\Processor;
 
 class Migrate extends Command
 {
-    protected $signature = Names::MIGRATE;
+    protected $signature = Names::ACTIONS;
 
     protected $description = 'Run the actions';
 

--- a/src/Constants/Names.php
+++ b/src/Constants/Names.php
@@ -10,7 +10,7 @@ class Names
 
     public const MAKE = 'make:action';
 
-    public const MIGRATE = 'actions';
+    public const ACTIONS = 'actions';
 
     public const REFRESH = 'actions:refresh';
 

--- a/src/Processors/Fresh.php
+++ b/src/Processors/Fresh.php
@@ -24,7 +24,7 @@ class Fresh extends Processor
 
     protected function migrate(): void
     {
-        $this->runCommand(Names::MIGRATE, [
+        $this->runCommand(Names::ACTIONS, [
             '--' . Options::CONNECTION => $this->options->connection,
             '--' . Options::PATH       => $this->options->path,
             '--' . Options::REALPATH   => true,

--- a/src/Processors/Refresh.php
+++ b/src/Processors/Refresh.php
@@ -30,7 +30,7 @@ class Refresh extends Processor
 
     protected function runMigrate(?string $connection, ?string $path, bool $realPath = true): void
     {
-        $this->runCommand(Names::MIGRATE, [
+        $this->runCommand(Names::ACTIONS, [
             '--' . Options::CONNECTION => $connection,
             '--' . Options::PATH       => $path,
             '--' . Options::REALPATH   => $realPath,

--- a/tests/Commands/ActionsTest.php
+++ b/tests/Commands/ActionsTest.php
@@ -21,7 +21,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($this->table, 0);
 
         $this->artisan(Names::MAKE, ['name' => 'TestMigration'])->assertExitCode(0);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($this->table, 1);
         $this->assertDatabaseMigrationHas($this->table, 'test_migration');
@@ -41,7 +41,7 @@ class ActionsTest extends TestCase
         sleep(2);
 
         $this->artisan(Names::MAKE, ['name' => 'TestMigration'])->assertExitCode(0);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($this->table, 2);
         $this->assertDatabaseMigrationHas($this->table, 'test_migration');
@@ -58,22 +58,22 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, $table);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 1);
         $this->assertDatabaseCount($this->table, 12);
         $this->assertDatabaseMigrationDoesntLike($this->table, $table);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 12);
         $this->assertDatabaseMigrationDoesntLike($this->table, $table);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 3);
         $this->assertDatabaseCount($this->table, 12);
         $this->assertDatabaseMigrationDoesntLike($this->table, $table);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 4);
         $this->assertDatabaseCount($this->table, 12);
@@ -91,7 +91,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, $table);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 3);
         $this->assertDatabaseCount($this->table, 1);
@@ -111,7 +111,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($this->table, $table);
 
         try {
-            $this->artisan(Names::MIGRATE)->assertExitCode(0);
+            $this->artisan(Names::ACTIONS)->assertExitCode(0);
         }
         catch (Exception $e) {
             $this->assertSame(Exception::class, get_class($e));
@@ -138,7 +138,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_on_testing');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_except_production');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_except_testing');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 5);
         $this->assertDatabaseCount($this->table, 12);
@@ -147,7 +147,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseMigrationHas($this->table, 'run_on_testing');
         $this->assertDatabaseMigrationHas($this->table, 'run_except_production');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_except_testing');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 5);
         $this->assertDatabaseCount($this->table, 12);
@@ -175,7 +175,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_except_production');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_except_testing');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_except_many_environments');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 5);
         $this->assertDatabaseCount($this->table, 12);
@@ -186,7 +186,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseMigrationHas($this->table, 'run_except_production');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_except_testing');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_except_many_environments');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 5);
         $this->assertDatabaseCount($this->table, 12);
@@ -211,13 +211,13 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_allow');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_disallow');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 5);
         $this->assertDatabaseCount($this->table, 12);
         $this->assertDatabaseMigrationHas($this->table, 'run_allow');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_disallow');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 5);
         $this->assertDatabaseCount($this->table, 12);
@@ -236,7 +236,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_success');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 12);
@@ -254,7 +254,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_success_on_failed');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 12);
@@ -263,7 +263,7 @@ class ActionsTest extends TestCase
         try {
             $this->copySuccessFailureMethod();
 
-            $this->artisan(Names::MIGRATE)->assertExitCode(0);
+            $this->artisan(Names::ACTIONS)->assertExitCode(0);
         }
         catch (Throwable $e) {
             $this->assertInstanceOf(Exception::class, $e);
@@ -289,7 +289,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_failed');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 12);
@@ -307,7 +307,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_failed_failure');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 12);
@@ -316,7 +316,7 @@ class ActionsTest extends TestCase
         try {
             $this->copyFailedMethod();
 
-            $this->artisan(Names::MIGRATE)->assertExitCode(0);
+            $this->artisan(Names::ACTIONS)->assertExitCode(0);
         }
         catch (Throwable $e) {
             $this->assertInstanceOf(Exception::class, $e);
@@ -344,7 +344,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'baz');
-        $this->artisan(Names::MIGRATE, ['--path' => $path])->assertExitCode(0);
+        $this->artisan(Names::ACTIONS, ['--path' => $path])->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 1);
         $this->assertDatabaseCount($this->table, 1);
@@ -366,7 +366,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'baz');
-        $this->artisan(Names::MIGRATE, ['--path' => $path])->assertExitCode(0);
+        $this->artisan(Names::ACTIONS, ['--path' => $path])->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 1);
         $this->assertDatabaseCount($this->table, 1);
@@ -388,7 +388,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'baz');
-        $this->artisan(Names::MIGRATE, ['--path' => $path])->assertExitCode(0);
+        $this->artisan(Names::ACTIONS, ['--path' => $path])->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 2);
@@ -420,13 +420,13 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 12);
         $this->assertDatabaseMigrationHas($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationHas($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 12);
@@ -446,13 +446,13 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE, ['--before' => true])->assertExitCode(0);
+        $this->artisan(Names::ACTIONS, ['--before' => true])->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 1);
         $this->assertDatabaseCount($this->table, 11);
         $this->assertDatabaseMigrationHas($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE, ['--before' => true])->assertExitCode(0);
+        $this->artisan(Names::ACTIONS, ['--before' => true])->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 1);
         $this->assertDatabaseCount($this->table, 11);
@@ -472,25 +472,25 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE, ['--before' => true])->assertExitCode(0);
+        $this->artisan(Names::ACTIONS, ['--before' => true])->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 1);
         $this->assertDatabaseCount($this->table, 11);
         $this->assertDatabaseMigrationHas($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE, ['--before' => true])->assertExitCode(0);
+        $this->artisan(Names::ACTIONS, ['--before' => true])->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 1);
         $this->assertDatabaseCount($this->table, 11);
         $this->assertDatabaseMigrationHas($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 12);
         $this->assertDatabaseMigrationHas($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationHas($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 12);
@@ -514,7 +514,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($table, 'up_down', column: 'value');
         $this->assertDatabaseMigrationDoesntLike($table, 'invoke_down', column: 'value');
         $this->assertDatabaseMigrationDoesntLike($table, 'invoke', column: 'value');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 3);
         $this->assertDatabaseCount($this->table, 3);
@@ -550,7 +550,7 @@ class ActionsTest extends TestCase
         $files[] = date('Y_m_d_His_') . 'test6';
         $this->artisan(Names::MAKE, ['name' => 'test6'])->assertExitCode(0);
 
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
         $this->assertDatabaseCount($this->table, 6);
 
         $records = DB::table($this->table)->orderBy('id')->pluck('action')->toArray();
@@ -574,7 +574,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2021_12_15_205804_baz');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2022_10_27_230732_foo');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 1);
         $this->assertDatabaseCount($this->table, 10);
@@ -582,7 +582,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2021_12_15_205804_baz');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2022_10_27_230732_foo');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 10);
@@ -590,7 +590,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2021_12_15_205804_baz');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2022_10_27_230732_foo');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 3);
         $this->assertDatabaseCount($this->table, 10);
@@ -598,7 +598,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2021_12_15_205804_baz');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2022_10_27_230732_foo');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 4);
         $this->assertDatabaseCount($this->table, 10);
@@ -623,28 +623,28 @@ class ActionsTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($this->table, $table);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2021_12_15_205804_baz');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2022_10_27_230732_foo');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 1);
         $this->assertDatabaseCount($this->table, 11);
         $this->assertDatabaseMigrationDoesntLike($this->table, $table);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2021_12_15_205804_baz');
         $this->assertDatabaseMigrationHas($this->table, 'sub_path/2022_10_27_230732_foo');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 11);
         $this->assertDatabaseMigrationDoesntLike($this->table, $table);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2021_12_15_205804_baz');
         $this->assertDatabaseMigrationHas($this->table, 'sub_path/2022_10_27_230732_foo');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 3);
         $this->assertDatabaseCount($this->table, 11);
         $this->assertDatabaseMigrationDoesntLike($this->table, $table);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'sub_path/2021_12_15_205804_baz');
         $this->assertDatabaseMigrationHas($this->table, 'sub_path/2022_10_27_230732_foo');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 4);
         $this->assertDatabaseCount($this->table, 11);
@@ -664,7 +664,7 @@ class ActionsTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, $table);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);

--- a/tests/Commands/FreshTest.php
+++ b/tests/Commands/FreshTest.php
@@ -19,7 +19,7 @@ class FreshTest extends TestCase
         $this->assertDatabaseCount($this->table, 0);
 
         $this->artisan(Names::MAKE, ['name' => 'Fresh'])->assertExitCode(0);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseHasTable($this->table);
         $this->assertDatabaseCount($this->table, 1);

--- a/tests/Commands/RefreshTest.php
+++ b/tests/Commands/RefreshTest.php
@@ -17,7 +17,7 @@ class RefreshTest extends TestCase
         $this->assertDatabaseCount($this->table, 0);
 
         $this->artisan(Names::MAKE, ['name' => 'Refresh'])->assertExitCode(0);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseHasTable($this->table);
         $this->assertDatabaseCount($this->table, 1);

--- a/tests/Commands/ResetTest.php
+++ b/tests/Commands/ResetTest.php
@@ -17,7 +17,7 @@ class ResetTest extends TestCase
         $this->assertDatabaseCount($this->table, 0);
 
         $this->artisan(Names::MAKE, ['name' => 'Reset'])->assertExitCode(0);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseHasTable($this->table);
         $this->assertDatabaseCount($this->table, 1);

--- a/tests/Commands/RollbackTest.php
+++ b/tests/Commands/RollbackTest.php
@@ -22,7 +22,7 @@ class RollbackTest extends TestCase
         $this->artisan(Names::MAKE, ['name' => 'RollbackOne'])->assertExitCode(0);
         $this->artisan(Names::MAKE, ['name' => 'RollbackTwo'])->assertExitCode(0);
 
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseHasTable($this->table);
         $this->assertDatabaseCount($this->table, 2);
@@ -36,13 +36,13 @@ class RollbackTest extends TestCase
         $this->assertDatabaseHasTable($this->table);
         $this->assertDatabaseCount($this->table, 0);
 
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseHasTable($this->table);
         $this->assertDatabaseCount($this->table, 2);
 
         $this->artisan(Names::MAKE, ['name' => 'RollbackTree'])->assertExitCode(0);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseHasTable($this->table);
         $this->assertDatabaseCount($this->table, 3);
@@ -66,7 +66,7 @@ class RollbackTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_on_production');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_on_testing');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_on_many_environments');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 5);
         $this->assertDatabaseCount($this->table, 12);
@@ -74,7 +74,7 @@ class RollbackTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_on_production');
         $this->assertDatabaseMigrationHas($this->table, 'run_on_testing');
         $this->assertDatabaseMigrationHas($this->table, 'run_on_many_environments');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->artisan(Names::ROLLBACK)->assertExitCode(0);
         $this->assertDatabaseCount($table, 10);
@@ -96,7 +96,7 @@ class RollbackTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_success');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 12);
@@ -119,7 +119,7 @@ class RollbackTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_success_on_failed');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 12);
@@ -160,7 +160,7 @@ class RollbackTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_failed');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 12);
@@ -183,7 +183,7 @@ class RollbackTest extends TestCase
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'run_failed_failure');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 0);
         $this->assertDatabaseCount($this->table, 12);
@@ -221,13 +221,13 @@ class RollbackTest extends TestCase
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 2);
         $this->assertDatabaseCount($this->table, 12);
         $this->assertDatabaseMigrationHas($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationHas($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->artisan(Names::ROLLBACK)->assertExitCode(0);
 
@@ -249,13 +249,13 @@ class RollbackTest extends TestCase
         $this->assertDatabaseCount($this->table, 0);
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE, ['--before' => true])->assertExitCode(0);
+        $this->artisan(Names::ACTIONS, ['--before' => true])->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 1);
         $this->assertDatabaseCount($this->table, 11);
         $this->assertDatabaseMigrationHas($this->table, 'test_before_enabled');
         $this->assertDatabaseMigrationDoesntLike($this->table, 'test_before_disabled');
-        $this->artisan(Names::MIGRATE, ['--before' => true])->assertExitCode(0);
+        $this->artisan(Names::ACTIONS, ['--before' => true])->assertExitCode(0);
 
         $this->artisan(Names::ROLLBACK)->assertExitCode(0);
 
@@ -281,7 +281,7 @@ class RollbackTest extends TestCase
         $this->assertDatabaseMigrationDoesntLike($table, 'up_down', column: 'value');
         $this->assertDatabaseMigrationDoesntLike($table, 'invoke_down', column: 'value');
         $this->assertDatabaseMigrationDoesntLike($table, 'invoke', column: 'value');
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($table, 3);
         $this->assertDatabaseCount($this->table, 3);

--- a/tests/Commands/StatusTest.php
+++ b/tests/Commands/StatusTest.php
@@ -28,7 +28,7 @@ class StatusTest extends TestCase
         $this->artisan(Names::STATUS)->expectsTable([], [])->assertExitCode(0);
 
         $this->artisan(Names::MAKE, ['name' => 'Status'])->assertExitCode(0);
-        $this->artisan(Names::MIGRATE)->assertExitCode(0);
+        $this->artisan(Names::ACTIONS)->assertExitCode(0);
 
         $this->assertDatabaseCount($this->table, 1);
 


### PR DESCRIPTION
<!--
Pull requests without a descriptive title, thorough description, or tests will be closed.

In addition, please describe the benefit to end users; the reasons it does not break any existing features; how it makes building web applications easier, etc.
-->
